### PR TITLE
Reuse fn that generate feature not available error

### DIFF
--- a/src/accessibility/useAccessibility.ts
+++ b/src/accessibility/useAccessibility.ts
@@ -1,7 +1,7 @@
 import { useState, useEffect } from 'react';
 import { Plugins } from '@capacitor/core';
-import { isFeatureAvailable } from '../util/feature-check';
-import { AvailableResult, notAvailable, FeatureNotAvailableError } from '../util/models';
+import { isFeatureAvailable, featureNotAvailableError } from '../util/feature-check';
+import { AvailableResult, notAvailable } from '../util/models';
 
 interface IsScreenReaderEnabledResult extends AvailableResult { isScreenReaderEnabled?: boolean; }
 interface SpeakResult extends AvailableResult { speak: typeof Plugins.Accessibility.speak; }
@@ -40,7 +40,7 @@ export function useSpeak(): SpeakResult {
   const { Accessibility } = Plugins;
   if(!availableFeatures.speak) {
     return {
-      speak: () => {throw new FeatureNotAvailableError()},
+      speak: featureNotAvailableError,
       ...notAvailable
     }
   }

--- a/src/browser/useBrowser.ts
+++ b/src/browser/useBrowser.ts
@@ -1,8 +1,8 @@
 import { Plugins } from '@capacitor/core';
-import { AvailableResult, notAvailable, FeatureNotAvailableError } from '../util/models';
-import { isFeatureAvailable } from '../util/feature-check';
+import { AvailableResult, notAvailable } from '../util/models';
+import { isFeatureAvailable, featureNotAvailableError } from '../util/feature-check';
 
-interface CloseResult extends AvailableResult { close: typeof Plugins.Browser.close }
+interface CloseResult extends AvailableResult { close: typeof Plugins.Browser.close | void }
 interface OpenResult extends AvailableResult { open: typeof Plugins.Browser.open }
 interface PrefetchResult extends AvailableResult { prefetch: typeof Plugins.Browser.prefetch }
 
@@ -17,7 +17,7 @@ export function useClose(): CloseResult {
 
   if (!availableFeatures.open) {
     return {
-      close: () => { throw new FeatureNotAvailableError() },
+      close: featureNotAvailableError,
       ...notAvailable
     }
   } 
@@ -33,7 +33,7 @@ export function useOpen(): OpenResult {
 
   if (!availableFeatures.open) {
     return {
-      open: () => { throw new FeatureNotAvailableError() },
+      open: featureNotAvailableError,
       ...notAvailable
     }
   }
@@ -49,7 +49,7 @@ export function usePrefetch(): PrefetchResult {
   
   if (!availableFeatures.prefetch) {
     return {
-      prefetch: () => { throw new FeatureNotAvailableError() },
+      prefetch: featureNotAvailableError,
       ...notAvailable
     }
   }

--- a/src/camera/useCamera.ts
+++ b/src/camera/useCamera.ts
@@ -1,6 +1,6 @@
 import { Plugins, CameraOptions, CameraPhoto } from '@capacitor/core';
-import { AvailableResult, notAvailable, FeatureNotAvailableError } from '../util/models';
-import { isFeatureAvailable } from '../util/feature-check';
+import { AvailableResult, notAvailable } from '../util/models';
+import { isFeatureAvailable, featureNotAvailableError } from '../util/feature-check';
 import { useState } from 'react';
 
 interface CameraResult extends AvailableResult { photo?: CameraPhoto, getPhoto: (options: CameraOptions) => void };
@@ -16,7 +16,7 @@ export function useCamera(): CameraResult {
 
   if(!availableFeatures.getPhoto) {
     return {
-      getPhoto: () => {throw new FeatureNotAvailableError()},
+      getPhoto: featureNotAvailableError,
       ...notAvailable
     }
   }

--- a/src/clipboard/useClipboard.ts
+++ b/src/clipboard/useClipboard.ts
@@ -1,7 +1,7 @@
 import { useState } from 'react';
 import { Plugins } from '@capacitor/core';
-import { AvailableResult, notAvailable, FeatureNotAvailableError } from '../util/models';
-import { isFeatureAvailable } from '../util/feature-check';
+import { AvailableResult, notAvailable } from '../util/models';
+import { isFeatureAvailable, featureNotAvailableError } from '../util/feature-check';
 
 interface ClipboardResult extends AvailableResult {
   value?: string,
@@ -18,8 +18,8 @@ export function useClipboard(): ClipboardResult {
   
   if (!(availableFeatures.useClipboard)) {
     return {
-      getValue: () => { throw new FeatureNotAvailableError() },
-      setValue: () => { throw new FeatureNotAvailableError() },
+      getValue: featureNotAvailableError,
+      setValue: featureNotAvailableError,
       ...notAvailable
     }
   }

--- a/src/geolocation/useGeolocation.ts
+++ b/src/geolocation/useGeolocation.ts
@@ -1,7 +1,7 @@
 import { useState, useEffect, useCallback } from 'react';
 import { Plugins, GeolocationPosition, GeolocationOptions } from '@capacitor/core';
-import { AvailableResult, notAvailable, FeatureNotAvailableError } from '../util/models';
-import { isFeatureAvailable } from '../util/feature-check';
+import { AvailableResult, notAvailable } from '../util/models';
+import { isFeatureAvailable, featureNotAvailableError } from '../util/feature-check';
 
 interface GetCurrentPositionResult extends AvailableResult {
   error?: any,
@@ -26,7 +26,7 @@ export function useCurrentPosition(options?: GeolocationOptions): GetCurrentPosi
 
   if (!availableFeatures.getCurrentPosition) {
     return {
-      getPosition: () => { throw new FeatureNotAvailableError() },
+      getPosition: featureNotAvailableError,
       ...notAvailable
     }
   }
@@ -74,8 +74,8 @@ export function useWatchPosition(): GeoWatchPositionResult {
 
   if (!availableFeatures.watchPosition) {
     return {
-      clearWatch: () => { throw new FeatureNotAvailableError() },
-      startWatch: () => { throw new FeatureNotAvailableError() },
+      clearWatch: featureNotAvailableError,
+      startWatch: featureNotAvailableError,
       ...notAvailable
     };
   }

--- a/src/storage/useStorage.ts
+++ b/src/storage/useStorage.ts
@@ -1,8 +1,8 @@
 // Inspired by useLocalStorage from https://usehooks.com/useLocalStorage/
 import { useState, useEffect } from 'react';
 import { Plugins } from '@capacitor/core';
-import { AvailableResult, notAvailable, FeatureNotAvailableError } from '../util/models';
-import { isFeatureAvailable } from '../util/feature-check';
+import { AvailableResult, notAvailable } from '../util/models';
+import { isFeatureAvailable, featureNotAvailableError } from '../util/feature-check';
 
 interface StorageResult extends AvailableResult {
   get: (key: string) => Promise<string | null>;
@@ -27,11 +27,11 @@ export function useStorage(): StorageResult {
 
   if (!availableFeatures.useStorage) {
     return {
-      get: () => { throw new FeatureNotAvailableError() },
-      set: () => { throw new FeatureNotAvailableError() },
-      remove: () => { throw new FeatureNotAvailableError() },
-      getKeys: () => { throw new FeatureNotAvailableError() },
-      clear: () => { throw new FeatureNotAvailableError() },
+      get: featureNotAvailableError,
+      set: featureNotAvailableError,
+      remove: featureNotAvailableError,
+      getKeys: featureNotAvailableError,
+      clear: featureNotAvailableError,
       ...notAvailable
     };
   }
@@ -69,7 +69,7 @@ export function useStorageItem<T>(key: string, initialValue?: T): StorageItemRes
   if (!availableFeatures.useStorage) {
     return [
       undefined,
-      () => { throw new FeatureNotAvailableError() },
+      featureNotAvailableError,
       false
     ];
   }

--- a/src/util/feature-check.ts
+++ b/src/util/feature-check.ts
@@ -1,5 +1,6 @@
 import { Capacitor } from '@capacitor/core';
 import { platform } from 'os';
+import { FeatureNotAvailableError } from './models';
 
 const allTrue = {
   web: true,
@@ -62,4 +63,8 @@ export function isFeatureAvailable<
       return true;
     }
     return false;
+}
+
+export function featureNotAvailableError(): any {
+  throw new FeatureNotAvailableError()
 }


### PR DESCRIPTION
Had to type the function `featureNotAvailableError` as any because Typescript would comply on many places and I didn't found an elegant way to deal with that.