### PR TITLE
Add manual flag to useCurrentPosition hook

### DIFF
--- a/src/geolocation/useGeolocation.ts
+++ b/src/geolocation/useGeolocation.ts
@@ -21,7 +21,7 @@ export const availableFeatures = {
   watchPosition: isFeatureAvailable('Geolocation', 'watchPosition')
 }
 
-export function useCurrentPosition(options?: GeolocationOptions): GetCurrentPositionResult {
+export function useCurrentPosition(options?: GeolocationOptions, manual: boolean = false): GetCurrentPositionResult {
   const { Geolocation } = Plugins;
 
   if (!availableFeatures.getCurrentPosition) {
@@ -58,8 +58,8 @@ export function useCurrentPosition(options?: GeolocationOptions): GetCurrentPosi
   };
 
   useEffect(() => {
-    getPosition(options);
-  }, [options]);
+    if(!manual) getPosition(options);
+  }, [options, manual]);
 
   return {
     error,


### PR DESCRIPTION
This provides an optional flag that will allow a developer to manually invoke the currentPosition the first time or for it to automatically grab it. This is to allow developers full control over when we want to get the currentPosition or not.